### PR TITLE
Fix csLow without corresponding csHigh

### DIFF
--- a/OpenBCI_8bit_Library/OpenBCI_8/ADS1299.cpp
+++ b/OpenBCI_8bit_Library/OpenBCI_8/ADS1299.cpp
@@ -529,7 +529,7 @@ void ADS1299::WREGS(byte _address, byte _numRegistersMinusOne) {
   for (int i=_address; i <=(_address + _numRegistersMinusOne); i++){
     xfer(regData[i]);     //  Write to the registers
   } 
-  digitalWrite(CS,HIGH);        //  close SPI
+  csHigh();        //  close SPI
   if(verbosity){
     Serial.print(F("Registers "));
     printHex(_address); Serial.print(F(" to "));


### PR DESCRIPTION
`csLow()` sets the SPI speed to 4MHz, so when `ADS_SS` is toggled high again, the SPI speed needs to be set back to the default 20MHz used for the SD card.
